### PR TITLE
Add FXFormFieldValueTransformer option

### DIFF
--- a/FXForms/FXForms.h
+++ b/FXForms/FXForms.h
@@ -44,6 +44,7 @@ static NSString *const FXFormFieldCell = @"cell";
 static NSString *const FXFormFieldTitle = @"title";
 static NSString *const FXFormFieldAction = @"action";
 static NSString *const FXFormFieldOptions = @"options";
+static NSString *const FXFormFieldValueTransformer = @"valueTransformer";
 static NSString *const FXFormFieldHeader = @"header";
 static NSString *const FXFormFieldFooter = @"footer";
 static NSString *const FXFormFieldInline = @"inline";
@@ -92,6 +93,7 @@ static NSString *const FXFormFieldTypeDateTime = @"datetime";
 @property (nonatomic, readonly) NSString *type;
 @property (nonatomic, readonly) NSString *title;
 @property (nonatomic, readonly) NSArray *options;
+@property (nonatomic, readonly) NSValueTransformer *valueTransformer;
 @property (nonatomic, readonly) SEL action;
 @property (nonatomic, strong) id value;
 

--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -385,6 +385,9 @@ static inline NSArray *FXFormProperties(id<FXForm> form)
         }
         return nil;
     }
+    if (self.valueTransformer) {
+        return [self.valueTransformer transformedValue:[self.value fieldDescription]];
+    }
     return [self.value fieldDescription];
 }
 
@@ -442,6 +445,11 @@ static inline NSArray *FXFormProperties(id<FXForm> form)
     _options = [options copy];
 }
 
+- (void)setValueTransformer:(NSValueTransformer *)valueTransformer
+{
+    _valueTransformer = valueTransformer;
+}
+
 - (void)performActionWithResponder:(UIResponder *)responder sender:(id)sender
 {
     if (self.action)
@@ -491,7 +499,7 @@ static inline NSArray *FXFormProperties(id<FXForm> form)
         for (id option in field.options)
         {
             [fields addObject:@{FXFormFieldKey: [@(index) description],
-                                FXFormFieldTitle: [option fieldDescription],
+                                FXFormFieldTitle: [field.valueTransformer transformedValue:option] ?: [option fieldDescription],
                                 FXFormFieldType: FXFormFieldTypeOption}];
             index ++;
         }


### PR DESCRIPTION
This adds a `FXFormFieldValueTransformer` option.

This makes it a bit easier to work with string enums, such as e.g. locals.

I have a `Customer` form which has a `region` field. My supported regions are e.g.:

`@[@"BE-VLG", @"BE-BRU", @"BE-WAL", @"NL", @"DE", @"FR", @"LU"]`

But I would like to show them as:

`@[@"Flanders", @"Brussels", @"Wallonia", @"Netherlands", @"Germany", @"France", @"Luxemburg"]`

With this patch, I can define the region field as follows:

``` Objective-C
@{
    FXFormFieldKey: @"region",
    FXFormFieldTitle: NSLocalizedString(@"Region", nil),
    FXFormFieldOptions: @[@"BE-VLG", @"BE-BRU", @"BE-WAL", @"NL", @"DE", @"FR", @"LU"],
    FXFormFieldValueTransformer: [NSValueTransformer valueTransformerForName:ISO33612ValueTransformerName],
}
```

As a side-note, I'm wondering if you'd be interested in allowing `FXOptionsForm`s to work with a datasource. I think it would be an awesome option to have for complexer option forms.

In my region example, it would allow me to group `Flanders`, `Brussels` and `Wallonia` under the `Belgium section`.
