### PR TITLE
Assign the correct form to self.formController.form

### DIFF
--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -1043,7 +1043,7 @@ static inline NSArray *FXFormProperties(id<FXForm> form)
     }
     
     self.title = field.title;
-    self.formController.form = field.value;
+    self.formController.form = form;
     
     //TODO: find a way to do this can doesn't rely on FXFormField having a private reference to formController
     //so that custom implementations can also benefit from this behavior


### PR DESCRIPTION
This fixes a small bug that caused `FXOptionsForm`s to not be shown.
