### PR TITLE
Allow FXFormFieldTypeOption fields to work again

### DIFF
--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -374,7 +374,7 @@ static BOOL *FXFormCanSetValueForKey(id<FXForm> form, NSString *key)
             {
                 dictionary[FXFormFieldViewController] = NSClassFromString(dictionary[FXFormFieldViewController]);
             }
-            if ([(NSArray *)dictionary[FXFormFieldOptions] count] && !dictionary[FXFormFieldType])
+            if ([(NSArray *)dictionary[FXFormFieldOptions] count])
             {
                 dictionary[FXFormFieldType] = FXFormFieldTypeDefault;
             }


### PR DESCRIPTION
Sorry, introduced a bug in the FXFormOptionPickerCell branch that turned regular
FXFormFieldTypeOption fields into FXFormFieldTypeDefault fields.

This PR fixes that problem
