### PR TITLE
Removed the call to action in the update function of FXFormStepperCell

### DIFF
--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -2075,7 +2075,6 @@ static BOOL *FXFormCanSetValueForKey(id<FXForm> form, NSString *key)
 {
     self.textLabel.text = self.field.title;
     self.switchControl.on = [self.field.value boolValue];
-    if (self.field.action) self.field.action(self);
 }
 
 - (UISwitch *)switchControl


### PR DESCRIPTION
When implementing the dynamic forms as described in nicklockwood/FXForms#26, the call to `action` in the `update` function will produce a recursion. The aoter cells don't call  `action` in the `update` function.
