### PR TITLE
FXFormOptionPickerCell doesn't select the current value

### DIFF
--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -2381,15 +2381,8 @@ static BOOL *FXFormCanSetValueForKey(id<FXForm> form, NSString *key)
     return YES;
 }
 
-- (UIView *)inputView
+- (BOOL)becomeFirstResponder
 {
-    return self.pickerView;
-}
-
-- (void)didSelectWithTableView:(UITableView *)tableView controller:(__unused UIViewController *)controller
-{
-    [self becomeFirstResponder];
-    
     NSUInteger index = self.field.value? [self.field.options indexOfObject:self.field.value]: NSNotFound;
     if (self.field.placeholder)
     {
@@ -2400,6 +2393,17 @@ static BOOL *FXFormCanSetValueForKey(id<FXForm> form, NSString *key)
         [self.pickerView selectRow:index inComponent:0 animated:NO];
     }
     
+    return [super becomeFirstResponder];
+}
+
+- (UIView *)inputView
+{
+    return self.pickerView;
+}
+
+- (void)didSelectWithTableView:(UITableView *)tableView controller:(__unused UIViewController *)controller
+{
+    [self becomeFirstResponder];
     [tableView selectRowAtIndexPath:nil animated:YES scrollPosition:UITableViewScrollPositionNone];
 }
 


### PR DESCRIPTION
The cell did not select the correct value inside the picker when becoming the first responder programatically. For example if you click on the _Next_ button on the text keyboard.
