### PR TITLE
Add FXFormOptionSegmentsCell, for short option lists.

### DIFF
--- a/Examples/BasicExample/Classes/RegistrationForm.h
+++ b/Examples/BasicExample/Classes/RegistrationForm.h
@@ -45,6 +45,8 @@ typedef NS_OPTIONS(NSInteger, Interests)
 @property (nonatomic, assign) Interests otherInterests;
 @property (nonatomic, copy) NSString *about;
 
+@property (nonatomic, copy) NSString *plan;
+
 @property (nonatomic, copy) NSString *notifications;
 
 @property (nonatomic, readonly) TermsViewController *termsAndConditions;

--- a/Examples/BasicExample/Classes/RegistrationForm.m
+++ b/Examples/BasicExample/Classes/RegistrationForm.m
@@ -88,6 +88,13 @@
              
              @{FXFormFieldKey: @"about", FXFormFieldType: FXFormFieldTypeLongText},
              
+             @{FXFormFieldHeader: @"Plan",
+               FXFormFieldKey: @"plan",
+               FXFormFieldTitle: @"",
+               FXFormFieldPlaceholder: @"Free",
+               FXFormFieldOptions: @[@"Micro", @"Normal", @"Maxi"],
+               FXFormFieldCell: [FXFormOptionSegmentsCell class]},
+             
              //we want to add a section header here, so we use another config dictionary
              
              @{FXFormFieldKey: @"termsAndConditions", FXFormFieldHeader: @"Legal"},

--- a/FXForms/FXForms.h
+++ b/FXForms/FXForms.h
@@ -237,5 +237,12 @@ static NSString *const FXFormFieldTypeImage = @"image";
 @end
 
 
+@interface FXFormOptionSegmentsCell : FXFormBaseCell
+
+@property (nonatomic, readonly) UISegmentedControl *segmentedControl;
+
+@end
+
+
 #pragma GCC diagnostic pop
 


### PR DESCRIPTION
Also added an example. The SegmentedControl will try to use the entire cell width if the `FXFormFieldTitle` value is an empty string.
