### PR TITLE
UITableViewController scrolling and offset fix

### DIFF
--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -1371,7 +1371,7 @@ static BOOL *FXFormCanSetValueForKey(id<FXForm> form, NSString *key)
 - (void)keyboardWillShow:(NSNotification *)note
 {
     UITableViewCell *cell = [self cellContainingView:FXFormsFirstResponder(self.tableView)];
-    if (cell && [[self class] isSubclassOfClass:[UITableViewController class]])
+    if (cell && ![[self.delegate class] isSubclassOfClass:[UITableViewController class]])
     {
         NSDictionary *keyboardInfo = [note userInfo];
         CGRect keyboardFrame = [keyboardInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue];
@@ -1399,7 +1399,7 @@ static BOOL *FXFormCanSetValueForKey(id<FXForm> form, NSString *key)
 - (void)keyboardWillHide:(NSNotification *)note
 {
     UITableViewCell *cell = [self cellContainingView:FXFormsFirstResponder(self.tableView)];
-    if (cell && [[self class] isSubclassOfClass:[UITableViewController class]])
+    if (cell && ![[self.delegate class] isSubclassOfClass:[UITableViewController class]])
     {
         NSDictionary *keyboardInfo = [note userInfo];
         


### PR DESCRIPTION
Only mess with the content inset/offset when the view controller is NOT a table view controller. The UITableViewController already takes care of these behaviors. I was seeing issues when it was trying to duplicate it.
