### PR TITLE
Fix crash in Examples when tapping on Country in the Registration Form.

### DIFF
--- a/Examples/BasicExample/Classes/RegistrationForm.m
+++ b/Examples/BasicExample/Classes/RegistrationForm.m
@@ -58,7 +58,7 @@
              //so we've used the FXFormFieldValueTransformer option to supply a value transformer
              
              @{FXFormFieldKey: @"country",
-               FXFormFieldOptions: @[@"us", @"ca", @"uk", @"sa", @"be"],
+               FXFormFieldOptions: @[@"us", @"ca", @"gb", @"sa", @"be"],
                FXFormFieldPlaceholder: @"None",
                FXFormFieldValueTransformer: [[ISO3166CountryValueTransformer alloc] init]},
              

--- a/Examples/CustomFormControllerExample/Classes/RegistrationForm.m
+++ b/Examples/CustomFormControllerExample/Classes/RegistrationForm.m
@@ -58,7 +58,7 @@
              //so we've used the FXFormFieldValueTransformer option to supply a value transformer
              
              @{FXFormFieldKey: @"country",
-               FXFormFieldOptions: @[@"us", @"ca", @"uk", @"sa", @"be"],
+               FXFormFieldOptions: @[@"us", @"ca", @"gb", @"sa", @"be"],
                FXFormFieldValueTransformer: [[ISO3166CountryValueTransformer alloc] init]},
              
              // this is a option field that uses a FXFormOptionPickerCell to display the available


### PR DESCRIPTION
uk is not ISO-3166 compliant. The CountryValueTransfomer returned nil,
which was added to a collection causing the crash. Replaced it with gb
for United Kingdom.
