### PR TITLE
Cell settings should be applied before the value itself.

### DIFF
--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -1324,13 +1324,13 @@ static BOOL *FXFormCanSetValueForKey(id<FXForm> form, NSString *key)
 {
     FXFormField *field = [self fieldForIndexPath:indexPath];
 
-    //set form field
-    ((id<FXFormFieldCell>)cell).field = field;
-    
     //configure cell
     [field.cellConfig enumerateKeysAndObjectsUsingBlock:^(NSString *keyPath, id value, __unused BOOL *stop) {
         [cell setValue:value forKeyPath:keyPath];
     }];
+    
+    //set form field
+    ((id<FXFormFieldCell>)cell).field = field;
     
     //forward to delegate
     if ([self.delegate respondsToSelector:_cmd])


### PR DESCRIPTION
I switch the order in which the value and the cell configs are applied. 
I think the configs should be applied first in case it has an impact on the value(s).

e.g : I have a UISlider with specifics min and max values, in the current implementation the slider value would be applied before the cell configs. Or by defaults the min/max values of a uislider are 0/1, applying a value greater than that would not work.

Setting the new min and max value before setting the slider value fix everything.

Also, FXForms is great, thanks for your work.
