### PR TITLE
Replace UITextAlignmentCenter, which is deprecated, with NSTextAlignmentCenter

### DIFF
--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -1684,7 +1684,7 @@ static BOOL *FXFormSetValueForKey(id<FXForm> form, id value, NSString *key)
         else if (self.field.action)
         {
             self.accessoryType = UITableViewCellAccessoryNone;
-            self.textLabel.textAlignment = UITextAlignmentCenter;
+            self.textLabel.textAlignment = NSTextAlignmentCenter;
         }
         else
         {


### PR DESCRIPTION
Minor refactor.

Other parts of the code already use NSTextAlignment\* constants.
