### PR TITLE
Add UITapGestureRecognizer to contentView instead of cell itself

### DIFF
--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -1808,7 +1808,7 @@ static BOOL *FXFormSetValueForKey(id<FXForm> form, id value, NSString *key)
     self.textField.delegate = self;
     [self.contentView addSubview:self.textField];
     
-    [self addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self.textField action:NSSelectorFromString(@"becomeFirstResponder")]];
+    [self.contentView addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self.textField action:NSSelectorFromString(@"becomeFirstResponder")]];
 }
 
 - (void)dealloc
@@ -2035,7 +2035,7 @@ static BOOL *FXFormSetValueForKey(id<FXForm> form, id value, NSString *key)
     self.detailTextLabel.textAlignment = UITextAlignmentLeft;
     self.detailTextLabel.numberOfLines = 0;
     
-    [self addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self.textView action:NSSelectorFromString(@"becomeFirstResponder")]];
+    [self.contentView addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self.textView action:NSSelectorFromString(@"becomeFirstResponder")]];
 }
 
 - (void)dealloc


### PR DESCRIPTION
This allows the add and delete buttons that are added by `UITableViewCellEditingStyleInsert` and `UITableViewCellEditingStyleDelete` to intercept touches.

These styles aren't used yet, but seems like they will be in the future.
