### PR TITLE
Update field type for number fields

### DIFF
--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -1890,11 +1890,17 @@ static BOOL *FXFormSetValueForKey(id<FXForm> form, id value, NSString *key)
         self.textField.autocapitalizationType = UITextAutocapitalizationTypeSentences;
         self.textField.keyboardType = UIKeyboardTypeAlphabet;
     }
-    else if ([self.field.type isEqualToString:FXFormFieldTypeNumber] || [self.field.type isEqualToString:FXFormFieldTypeInteger])
+    else if ([self.field.type isEqualToString:FXFormFieldTypeNumber])
     {
         self.textField.autocorrectionType = UITextAutocorrectionTypeNo;
         self.textField.autocapitalizationType = UITextAutocapitalizationTypeNone;
-        self.textField.keyboardType = UIKeyboardTypeNumbersAndPunctuation;
+        self.textField.keyboardType = UIKeyboardTypeDecimalPad;
+    }
+    else if ([self.field.type isEqualToString:FXFormFieldTypeInteger])
+    {
+        self.textField.autocorrectionType = UITextAutocorrectionTypeNo;
+        self.textField.autocapitalizationType = UITextAutocapitalizationTypeNone;
+        self.textField.keyboardType = UIKeyboardTypeNumberPad;
     }
     else if ([self.field.type isEqualToString:FXFormFieldTypePassword])
     {


### PR DESCRIPTION
Use UIKeyboardTypeDecimalPad for FXFormFieldTypeNumber
UIKeyboardTypeNumberPad for FXFormFieldTypeInteger
