### PR TITLE
update textField on willEndEditing: if field.ValueTransformer

### DIFF
--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -1954,6 +1954,7 @@ static BOOL *FXFormSetValueForKey(id<FXForm> form, id value, NSString *key)
 
     self.field.value = value;
     if (self.field.action) self.field.action(self);
+    if (self.field.valueTransformer) [self update];
 }
 
 - (BOOL)textFieldShouldBeginEditing:(__unused UITextField *)textField


### PR DESCRIPTION
When using valueTransformers with a textField (a simple way to validate input) the valueTransformer wouldn't be called until the cell was reloaded. This checks for the presence of a valueTransformer on didEndEditing: and calls update if required.
