### PR TITLE
Left Aligned Text with Images

### DIFF
--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -1805,6 +1805,7 @@ static BOOL *FXFormSetValueForKey(id<FXForm> form, id value, NSString *key)
     self.textField.font = [UIFont systemFontOfSize:self.textLabel.font.pointSize];
     self.textField.minimumFontSize = FXFormLabelMinFontSize(self.textLabel);
     self.textField.textColor = [UIColor colorWithRed:0.275f green:0.376f blue:0.522f alpha:1.000f];
+    self.textField.textAlignment = NSTextAlignmentRight;
     self.textField.delegate = self;
     [self.contentView addSubview:self.textField];
     
@@ -1863,8 +1864,19 @@ static BOOL *FXFormSetValueForKey(id<FXForm> form, id value, NSString *key)
 	textFieldFrame.size.width = self.textField.superview.frame.size.width - textFieldFrame.origin.x - FXFormFieldPaddingRight;
 	if (![self.textLabel.text length])
     {
-		textFieldFrame.origin.x = FXFormFieldPaddingLeft;
-		textFieldFrame.size.width = self.contentView.bounds.size.width - FXFormFieldPaddingLeft - FXFormFieldPaddingRight;
+        // Nothing in the text label, look for an image
+        if (!self.imageView || !self.imageView.image)
+        {
+            // No image, just pad it
+            textFieldFrame.origin.x = FXFormFieldPaddingLeft;
+            textFieldFrame.size.width = self.contentView.bounds.size.width - FXFormFieldPaddingLeft - FXFormFieldPaddingRight;
+        }
+        else
+        {
+            // Got an image, pad from the image view
+            textFieldFrame.origin.x = CGRectGetMaxX(self.imageView.frame) + FXFormFieldLabelSpacing;
+            textFieldFrame.size.width = self.imageView.superview.frame.size.width - textFieldFrame.origin.x - FXFormFieldPaddingRight;
+        }
 	}
     else if (self.textField.textAlignment == NSTextAlignmentRight)
     {
@@ -1881,7 +1893,6 @@ static BOOL *FXFormSetValueForKey(id<FXForm> form, id value, NSString *key)
     self.textField.text = [self.field fieldDescription];
     
     self.textField.returnKeyType = UIReturnKeyDone;
-    self.textField.textAlignment = NSTextAlignmentRight;
     self.textField.secureTextEntry = NO;
     
     if ([self.field.type isEqualToString:FXFormFieldTypeText])


### PR DESCRIPTION
I've started using this via CocoaPods about a week ago and have been very happy, thanks for creating it!  I have made a couple changes; essentially, our UI calls for an image in the cell (using the default UITableViewCell's imageView has been sufficient) and left aligning the text.  To accomplish this, I needed to make the following two changes: 

1) Moved the right alignment call to setUp rather than update so the user decision doesn't get overridden all the time.
2) Added layout logic to account for cell images.

I hope these changes make sense, happy to answer any questions you may have.  

Thanks.
