### PR TITLE
fix FXFormImagePickerCell image width miscalculation

### DIFF
--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -2474,7 +2474,12 @@ static BOOL *FXFormSetValueForKey(id<FXForm> form, id value, NSString *key)
 {
     CGRect frame = self.imagePickerView.bounds;
     frame.size.height = self.bounds.size.height - 10;
-    frame.size.width = self.imagePickerView.image? self.imagePickerView.image.size.width / frame.size.height: 0;
+    if (self.imagePickerView.image) {
+        CGFloat ratio = frame.size.height / self.imagePickerView.image.size.height;
+        frame.size.width = self.imagePickerView.image.size.width * ratio;
+    } else {
+        frame.size.width = 0;
+    }
     self.imagePickerView.bounds = frame;
     
     [super layoutSubviews];


### PR DESCRIPTION
In FXFormImagePickerCell, the image's width is not correct, it will make the width smaller than usual.
