### PR TITLE
FXFormFieldTemplate: Add beginUpdates and endUpdates where necessary

### DIFF
--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -1241,13 +1241,18 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
         FXFormField *field = cell.field;
         FXFormController *formController = field.formController;
         UITableView *tableView = formController.tableView;
+        
+        [tableView beginUpdates];
+        
         NSIndexPath *indexPath = [tableView indexPathForCell:cell];
         FXFormSection *section = formController.sections[indexPath.section];
         [section addNewField];
 
         [tableView deselectRowAtIndexPath:indexPath animated:YES];
         [tableView insertRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
-        [[tableView cellForRowAtIndexPath:indexPath] becomeFirstResponder];
+        
+        [tableView endUpdates];
+        
         dispatch_async(dispatch_get_main_queue(), ^{
             
             [formController tableView:tableView didSelectRowAtIndexPath:indexPath];
@@ -1883,9 +1888,13 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
 {
     if (editingStyle == UITableViewCellEditingStyleDelete)
     {
+        [tableView beginUpdates];
+        
         FXFormSection *section = [self sectionAtIndex:indexPath.section];
         [section removeFieldAtIndex:indexPath.row];
         [tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+        
+        [tableView endUpdates];
     }
 }
 


### PR DESCRIPTION
This fixes a bug in the `TemplateFieldsExample` that you can reproduce as follows:
- Launch the simulator
- Add Item, don't fill out any text
- Delete the newly added item
- press Add Item again

A ton of empty new rows are now inserted into the tableview.
