### PR TITLE
Expose nextCell method in FXFormBaseCell

### DIFF
--- a/FXForms/FXForms.h
+++ b/FXForms/FXForms.h
@@ -203,6 +203,8 @@ static NSString *const FXFormFieldTypeImage = @"image";
 - (void)update;
 - (void)didSelectWithTableView:(UITableView *)tableView
                     controller:(UIViewController *)controller;
+
+- (UITableViewCell <FXFormFieldCell> *)nextCell;
 @end
 
 


### PR DESCRIPTION
Added in FXForms.h the nextCell method allowing custom cells to use this functionality