### PR TITLE
Ignore readonly properties

### DIFF
--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -130,6 +130,11 @@ static inline NSArray *FXFormProperties(id<FXForm> form)
                 objc_property_t property = propertyList[i];
                 const char *propertyName = property_getName(property);
                 NSString *key = @(propertyName);
+
+				if ([[[NSString stringWithUTF8String:property_getAttributes(property)] componentsSeparatedByString:@","] containsObject:@"R"]) {
+					//skip readonly properties
+					continue;
+				}
                 
                 //get property type
                 Class valueClass = nil;


### PR DESCRIPTION
I suggest readonly properties should not be included in the generated form. 

I originally added this to avoid having the recently added (Xcode 6 beta) extra NSObject properties show up, e.g. hash, description, debugDescription etc., (#154)

But I think it stands on its own, I don't see any need to include readonly properties in the generated form... Though perhaps I'm not considering all use cases; if there is a valid reason to have readonly properties included, then it should probably be conditional, and something else should be done to exclude the NSObject properties (which annoyingly show as being declared in your subclass, not on NSObject itself.)
