### PR TITLE
Use UITableViewAutomaticDimension for header/footer heights

### DIFF
--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -2055,7 +2055,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
     {
         return header.frame.size.height ?: 56; //standard height for header views
     }
-    return 38; //standard height for text headers
+    return UITableViewAutomaticDimension;
 }
 
 - (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)index
@@ -2089,7 +2089,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
     {
         return footer.frame.size.height ?: 46; //standard height for footer views
     }
-    return 30; //standard height for text footers
+    return UITableViewAutomaticDimension;
 }
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath


### PR DESCRIPTION
While 38 and 30 may be standard heights for table headers and footers, respectively, I wonder why not use `UITableViewAutomaticDimension`? It will size the header and footer appropriately for their text contents and does not require overriding a delegate method.

Thanks for a great library!
