### PR TITLE
A hotfix for build error .

### DIFF
--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -2665,7 +2665,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
         }
         else if ([self.field.viewController isKindOfClass:[UIViewController class]])
         {
-            subcontroller = self.field.viewController;
+            subcontroller = [[self.field.viewController alloc] init];
             ((id <FXFormFieldViewController>)subcontroller).field = self.field;
         }
         else


### PR DESCRIPTION
Line 2668: `subcontroller = self.field.viewController;` should be `subcontroller = [[self.field.viewController alloc] init];`
