### PR TITLE
Fix swift error, use rawValue instead.

### DIFF
--- a/Examples/SwiftExample/SwiftExample/RegistrationForm.swift
+++ b/Examples/SwiftExample/SwiftExample/RegistrationForm.swift
@@ -56,7 +56,7 @@ class RegistrationForm: NSObject, FXForm {
             //we want to add another group header here, and modify the auto-capitalization
             
             [FXFormFieldKey: "name", FXFormFieldHeader: "Details",
-                "textField.autocapitalizationType": UITextAutocapitalizationType.Words.toRaw()],
+                "textField.autocapitalizationType": UITextAutocapitalizationType.Words.rawValue],
 
             //this is a multiple choice field, so we'll need to provide some options
             //because this is an enum property, the indexes of the options should match enum values


### PR DESCRIPTION
'UITextAutocapitalizationType' does not have a member named 'toRaw'
