### PR TITLE
fix crash with string field footer

### DIFF
--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -520,7 +520,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
         }
         else
         {
-            dictionary[FXFormFieldFooter] = [header copy];
+            dictionary[FXFormFieldFooter] = [footer copy];
         }
     }
     else if ([footer isKindOfClass:[NSNull class]])


### PR DESCRIPTION
This fixes a crash in `FXFormPreprocessFieldDictionary` when you have a field configured with a footer, but not a header.
