### PR TITLE
Allow for hidden fields

### DIFF
--- a/FXForms/FXForms.h
+++ b/FXForms/FXForms.h
@@ -53,6 +53,7 @@ UIKIT_EXTERN NSString *const FXFormFieldSegue; //segue
 UIKIT_EXTERN NSString *const FXFormFieldHeader; //header
 UIKIT_EXTERN NSString *const FXFormFieldFooter; //footer
 UIKIT_EXTERN NSString *const FXFormFieldInline; //inline
+UIKIT_EXTERN NSString *const FXFormFieldHidden; //hidden
 UIKIT_EXTERN NSString *const FXFormFieldSortable; //sortable
 UIKIT_EXTERN NSString *const FXFormFieldViewController; //viewController
 

--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -57,6 +57,7 @@ NSString *const FXFormFieldSegue = @"segue";
 NSString *const FXFormFieldHeader = @"header";
 NSString *const FXFormFieldFooter = @"footer";
 NSString *const FXFormFieldInline = @"inline";
+NSString *const FXFormFieldHidden = @"hidden";
 NSString *const FXFormFieldSortable = @"sortable";
 NSString *const FXFormFieldViewController = @"viewController";
 
@@ -629,6 +630,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
 @property (nonatomic, readwrite) NSDictionary *fieldTemplate;
 @property (nonatomic, readwrite) BOOL isSortable;
 @property (nonatomic, readwrite) BOOL isInline;
+@property (nonatomic, readwrite) BOOL isHidden;
 @property (nonatomic, readonly) id (^valueTransformer)(id input);
 @property (nonatomic, readonly) id (^reverseValueTransformer)(id input);
 @property (nonatomic, strong) id defaultValue;
@@ -1091,6 +1093,11 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
 - (void)setInline:(BOOL)isInline
 {
     _isInline = isInline;
+}
+
+- (void)setHidden:(BOOL)isHidden
+{
+    _isHidden = isHidden;
 }
 
 - (void)setOptions:(NSArray *)options
@@ -2110,6 +2117,9 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
 {
     FXFormField *field = [self fieldForIndexPath:indexPath];
     Class cellClass = field.cellClass ?: [self cellClassForField:field];
+    if (field.isHidden) {
+        return 0;
+    }
     if ([cellClass respondsToSelector:@selector(heightForField:width:)])
     {
         return [cellClass heightForField:field width:self.tableView.frame.size.width];
@@ -2499,6 +2509,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
 {
     if ((self = [super initWithStyle:style reuseIdentifier:reuseIdentifier]))
     {
+        self.clipsToBounds = YES;
         self.textLabel.font = [UIFont boldSystemFontOfSize:17];
         FXFormLabelSetMinFontSize(self.textLabel, FXFormFieldMinFontSize);
         self.detailTextLabel.font = [UIFont systemFontOfSize:17];
@@ -2631,6 +2642,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
 
 - (void)update
 {
+    self.hidden = self.field.isHidden;
     self.textLabel.text = self.field.title;
     self.detailTextLabel.text = [self.field fieldDescription];
     
@@ -2844,6 +2856,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
 
 - (void)update
 {
+    self.hidden = self.field.isHidden;
     self.textLabel.text = self.field.title;
     self.textField.placeholder = [self.field.placeholder fieldDescription];
     self.textField.text = [self.field fieldDescription];
@@ -3053,6 +3066,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
 
 - (void)update
 {
+    self.hidden = self.field.isHidden;
     self.textLabel.text = self.field.title;
     self.textView.text = [self.field fieldDescription];
     self.detailTextLabel.text = self.field.placeholder;
@@ -3170,6 +3184,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
 
 - (void)update
 {
+    self.hidden = self.field.isHidden;
     self.textLabel.text = self.field.title;
     self.switchControl.on = [self.field.value boolValue];
 }
@@ -3209,6 +3224,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
 
 - (void)update
 {
+    self.hidden = self.field.isHidden;
     self.textLabel.text = self.field.title;
     self.detailTextLabel.text = [self.field fieldDescription];
     self.stepper.value = [self.field.value doubleValue];
@@ -3262,6 +3278,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
 
 - (void)update
 {
+    self.hidden = self.field.isHidden;
     self.textLabel.text = self.field.title;
     self.slider.value = [self.field.value doubleValue];
 }
@@ -3293,6 +3310,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
 
 - (void)update
 {
+    self.hidden = self.field.isHidden;
     self.textLabel.text = self.field.title;
     self.detailTextLabel.text = [self.field fieldDescription] ?: [self.field.placeholder fieldDescription];
     
@@ -3386,6 +3404,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
 
 - (void)update
 {
+    self.hidden = self.field.isHidden;
     self.textLabel.text = self.field.title;
     self.imagePickerView.image = [self imageValue];
     [self setNeedsLayout];
@@ -3527,6 +3546,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
 
 - (void)update
 {
+    self.hidden = self.field.isHidden;
     self.textLabel.text = self.field.title;
     self.detailTextLabel.text = [self.field fieldDescription];
     
@@ -3623,6 +3643,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
 
 - (void)update
 {
+    self.hidden = self.field.isHidden;
     self.textLabel.text = self.field.title;
     
     [self.segmentedControl removeAllSegments];


### PR DESCRIPTION
Gives the option to have a field be part of the form, but not displayed to the user. Can be used for examples like ‘created_date’ or other fields which might be set, but should not be visible. Also useful when conditionally reloading the form and deciding to hide/show a field based not the value or action of another field.