### PR TITLE
Applying reverseValueTransformer

### DIFF
--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -955,7 +955,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
         
         if (self.reverseValueTransformer)
         {
-            value = self.reverseValueTransformer;
+            value = self.reverseValueTransformer(value);
         }
         else if ([value isKindOfClass:[NSString class]])
         {


### PR DESCRIPTION
`value` must have the updated value, after going through the transformer (and not the transformer itself).
