### PR TITLE
Fixed some static analyzer warnings

### DIFF
--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -1600,6 +1600,8 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
     NSMutableDictionary *field = self.fields[index1];
     [self.fields removeObjectAtIndex:index1];
 
+	NSAssert(field, @"No Field at the given index.");
+
     id value = self.values[index1];
     [self.values removeObjectAtIndex:index1];
     

--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -2966,7 +2966,8 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
 
 - (BOOL)resignFirstResponder
 {
-    return [self.textField resignFirstResponder];
+    BOOL superResign = [super resignFirstResponder];
+    return [self.textField resignFirstResponder] && superResign;
 }
 
 @end
@@ -3155,7 +3156,8 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
 
 - (BOOL)resignFirstResponder
 {
-    return [self.textView resignFirstResponder];
+    BOOL superResign = [super resignFirstResponder];
+    return [self.textView resignFirstResponder] && superResign;
 }
 
 @end


### PR DESCRIPTION
This pull request fixes two static analyzer warnings.
1. resignFirstResponder must include a call to super. [reference](https://developer.apple.com/library/IOs/documentation/UIKit/Reference/UIResponder_Class/index.html#//apple_ref/occ/instm/UIResponder/resignFirstResponder)
2. If, for some reason field is nil in - (void)moveFieldAtIndex:(NSUInteger)index1 toIndex:(NSUInteger)index2, it will cause a call to -addObject: with a nil parameter which is a misuse of the API. [reference](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSMutableArray_Class/#//apple_ref/occ/instm/NSMutableArray/addObject:)
