### PR TITLE
Expose FXFormField.options array as readonly property.

### DIFF
--- a/FXForms/FXForms.h
+++ b/FXForms/FXForms.h
@@ -107,6 +107,7 @@ UIKIT_EXTERN NSString *const FXFormFieldTypeImage; //image
 
 @property (nonatomic, readonly) id<FXForm> form;
 @property (nonatomic, readonly) NSString *key;
+@property (nonatomic, readonly) NSArray *options;
 @property (nonatomic, readonly) NSString *type;
 @property (nonatomic, readonly) NSString *title;
 @property (nonatomic, readonly) id placeholder;


### PR DESCRIPTION
It is handy to obtain entire `options` array as readonly property. 

Sure there is `optionCount` and `optionAtIndex:...` which allows you to iterate through objects, but by accessing  `options` directly, the code will be more concise and easy to remember.

e.g.,

instead of 

```
  for (int i = 0; i < optionCount; i++) {
      id option = [field optionAtIndex:i];
      // do something with option
  }
```

we can do 

```
  for id option in field.options {
      // do something with option
  }
```

It is a subtle difference, but feel much better if you use in quite a few places.
