### PR TITLE
Bugfix regarding reverse value transformers

### DIFF
--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -958,7 +958,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
         
         if (self.reverseValueTransformer)
         {
-            value = self.reverseValueTransformer;
+            value = self.reverseValueTransformer(value);
         }
         else if ([value isKindOfClass:[NSString class]])
         {


### PR DESCRIPTION
The value transformer itself was being assigned as a value, and not the reversed value as expected