### PR TITLE
Carry cell configuration through to Options

### DIFF
--- a/Examples/BasicExample/Classes/RegistrationForm.m
+++ b/Examples/BasicExample/Classes/RegistrationForm.m
@@ -40,7 +40,10 @@
              //this is a multiple choice field, so we'll need to provide some options
              //because this is an enum property, the indexes of the options should match enum values
              
-             @{FXFormFieldKey: @"gender", FXFormFieldOptions: @[@"Male", @"Female", @"It's Complicated"]},
+             @{FXFormFieldKey: @"gender", FXFormFieldOptions: @[@"Male", @"Female", @"It's Complicated"],
+                   @"textLabel.color": [UIColor lightGrayColor],
+                   @"textLabel.font": [UIFont fontWithName:@"HelveticaNeue" size:16]
+                   },
              
              //another regular field
              

--- a/Examples/BasicExample/Classes/RegistrationForm.m
+++ b/Examples/BasicExample/Classes/RegistrationForm.m
@@ -40,10 +40,7 @@
              //this is a multiple choice field, so we'll need to provide some options
              //because this is an enum property, the indexes of the options should match enum values
              
-             @{FXFormFieldKey: @"gender", FXFormFieldOptions: @[@"Male", @"Female", @"It's Complicated"],
-                   @"textLabel.color": [UIColor lightGrayColor],
-                   @"textLabel.font": [UIFont fontWithName:@"HelveticaNeue" size:16]
-                   },
+             @{FXFormFieldKey: @"gender", FXFormFieldOptions: @[@"Male", @"Female", @"It's Complicated"]},
              
              //another regular field
              

--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -3307,6 +3307,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
     else
     {
         self.datePicker.datePickerMode = UIDatePickerModeDateAndTime;
+        self.datePicker.minimumDate = [NSDate date];
     }
     
     self.datePicker.date = self.field.value ?: ([self.field.placeholder isKindOfClass:[NSDate class]]? self.field.placeholder: [NSDate date]);

--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -757,7 +757,14 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
     {
         _form = form;
         _formController = formController;
-        _cellConfig = [NSMutableDictionary dictionary];
+        if (FXFormCanGetValueForKey(form, @"field") && FXFormCanGetValueForKey(form, @"field.cellConfig")) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wselector"
+            _cellConfig = [[form performSelector:@selector(field)] performSelector:@selector(cellConfig)];
+#pragma clang diagnostic pop
+        } else {
+            _cellConfig = [NSMutableDictionary dictionary];
+        }
         [attributes enumerateKeysAndObjectsUsingBlock:^(NSString *key, id value, __unused BOOL *stop) {
             [self setValue:value forKey:key];
         }];

--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -757,9 +757,11 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
     {
         _form = form;
         _formController = formController;
-        if (FXFormCanGetValueForKey(form, @"field") && FXFormCanGetValueForKey(form, @"field.cellConfig")) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wselector"
+        if (FXFormCanGetValueForKey(form, @"field")
+            && FXFormCanGetValueForKey(form, @"field.cellConfig")
+            && [[form performSelector:@selector(field)] performSelector:@selector(cellConfig)]) {
             _cellConfig = [[form performSelector:@selector(field)] performSelector:@selector(cellConfig)];
 #pragma clang diagnostic pop
         } else {

--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -3361,7 +3361,6 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
     else
     {
         self.datePicker.datePickerMode = UIDatePickerModeDateAndTime;
-        self.datePicker.minimumDate = [NSDate date];
     }
     
     self.datePicker.date = self.field.value ?: ([self.field.placeholder isKindOfClass:[NSDate class]]? self.field.placeholder: [NSDate date]);


### PR DESCRIPTION
This pull request just makes sure that when using an option picker, that the view controller which displays the options uses the same cell configuration as the cell which had been tapped.

See: https://github.com/nicklockwood/FXForms/issues/149