### PR TITLE
Removes selectAll on didBeginEditing for text

### DIFF
--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -2964,11 +2964,6 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
     return YES;
 }
 
-- (void)textFieldDidBeginEditing:(__unused UITextField *)textField
-{
-    [self.textField selectAll:nil];
-}
-
 - (void)textDidChange
 {
     [self updateFieldValue];
@@ -3152,11 +3147,6 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
         self.textView.autocapitalizationType = UITextAutocapitalizationTypeNone;
         self.textView.keyboardType = UIKeyboardTypeURL;
     }
-}
-
-- (void)textViewDidBeginEditing:(__unused UITextView *)textView
-{
-    [self.textView selectAll:nil];
 }
 
 - (void)textViewDidChange:(UITextView *)textView


### PR DESCRIPTION
This is a non-standard Apple behavior and was unexpected by users. Every time they went to edit text they had to double-tap to reposition the cursor to the end of the text to undo the selectAll, when that's what it should do by default.