### PR TITLE
Add support for accessibility labels on text fields.

### DIFF
--- a/FXForms/FXForms.h
+++ b/FXForms/FXForms.h
@@ -43,6 +43,7 @@ UIKIT_EXTERN NSString *const FXFormFieldType; //type
 UIKIT_EXTERN NSString *const FXFormFieldClass; //class
 UIKIT_EXTERN NSString *const FXFormFieldCell; //cell
 UIKIT_EXTERN NSString *const FXFormFieldTitle; //title
+UIKIT_EXTERN NSString *const FXFormFieldAccessibilityLabel; //accessibility label
 UIKIT_EXTERN NSString *const FXFormFieldPlaceholder; //placeholder
 UIKIT_EXTERN NSString *const FXFormFieldDefaultValue; //default
 UIKIT_EXTERN NSString *const FXFormFieldOptions; //options
@@ -109,6 +110,7 @@ UIKIT_EXTERN NSString *const FXFormFieldTypeImage; //image
 @property (nonatomic, readonly) NSString *key;
 @property (nonatomic, readonly) NSString *type;
 @property (nonatomic, readonly) NSString *title;
+@property (nonatomic, readonly) NSString *accessibilityLabel;
 @property (nonatomic, readonly) id placeholder;
 @property (nonatomic, readonly) NSDictionary *fieldTemplate;
 @property (nonatomic, readonly) BOOL isSortable;

--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -48,6 +48,7 @@ NSString *const FXFormFieldClass = @"class";
 NSString *const FXFormFieldCell = @"cell";
 NSString *const FXFormFieldTitle = @"title";
 NSString *const FXFormFieldPlaceholder = @"placeholder";
+NSString *const FXFormFieldAccessibilityLabel = @"accessibilityLabel";
 NSString *const FXFormFieldDefaultValue = @"default";
 NSString *const FXFormFieldOptions = @"options";
 NSString *const FXFormFieldTemplate = @"template";
@@ -649,6 +650,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
 @property (nonatomic, strong) Class valueClass;
 @property (nonatomic, strong) Class cellClass;
 @property (nonatomic, readwrite) NSString *key;
+@property (nonatomic, strong) NSString *accessibilityLabel;
 @property (nonatomic, readwrite) NSArray *options;
 @property (nonatomic, readwrite) NSDictionary *fieldTemplate;
 @property (nonatomic, readwrite) BOOL isSortable;
@@ -2901,6 +2903,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
 - (void)update
 {
     self.textLabel.text = self.field.title;
+    self.textField.accessibilityLabel = self.field.accessibilityLabel;
     self.textField.placeholder = [self.field.placeholder fieldDescription];
     self.textField.text = [self.field fieldDescription];
     


### PR DESCRIPTION
This adds support for specifying accessibility labels for text fields. This is important not only for accessibility but also for automated UI testing. I can extend this to add accessibility labels to other types of UI controls if you think this approach is reasonable.