### PR TITLE
reloadData + valueForKeyPath

### DIFF
--- a/FXForms/FXForms.h
+++ b/FXForms/FXForms.h
@@ -43,6 +43,7 @@ UIKIT_EXTERN NSString *const FXFormFieldType; //type
 UIKIT_EXTERN NSString *const FXFormFieldClass; //class
 UIKIT_EXTERN NSString *const FXFormFieldCell; //cell
 UIKIT_EXTERN NSString *const FXFormFieldTitle; //title
+UIKIT_EXTERN NSString *const FXFormFieldDetail; //Detail
 UIKIT_EXTERN NSString *const FXFormFieldPlaceholder; //placeholder
 UIKIT_EXTERN NSString *const FXFormFieldDefaultValue; //default
 UIKIT_EXTERN NSString *const FXFormFieldOptions; //options
@@ -109,6 +110,7 @@ UIKIT_EXTERN NSString *const FXFormFieldTypeImage; //image
 @property (nonatomic, readonly) NSString *key;
 @property (nonatomic, readonly) NSString *type;
 @property (nonatomic, readonly) NSString *title;
+@property (nonatomic, readonly) NSString *detail;
 @property (nonatomic, readonly) id placeholder;
 @property (nonatomic, readonly) NSDictionary *fieldTemplate;
 @property (nonatomic, readonly) BOOL isSortable;

--- a/FXForms/FXForms.h
+++ b/FXForms/FXForms.h
@@ -43,7 +43,6 @@ UIKIT_EXTERN NSString *const FXFormFieldType; //type
 UIKIT_EXTERN NSString *const FXFormFieldClass; //class
 UIKIT_EXTERN NSString *const FXFormFieldCell; //cell
 UIKIT_EXTERN NSString *const FXFormFieldTitle; //title
-UIKIT_EXTERN NSString *const FXFormFieldDetail; //Detail
 UIKIT_EXTERN NSString *const FXFormFieldPlaceholder; //placeholder
 UIKIT_EXTERN NSString *const FXFormFieldDefaultValue; //default
 UIKIT_EXTERN NSString *const FXFormFieldOptions; //options
@@ -110,7 +109,6 @@ UIKIT_EXTERN NSString *const FXFormFieldTypeImage; //image
 @property (nonatomic, readonly) NSString *key;
 @property (nonatomic, readonly) NSString *type;
 @property (nonatomic, readonly) NSString *title;
-@property (nonatomic, readonly) NSString *detail;
 @property (nonatomic, readonly) id placeholder;
 @property (nonatomic, readonly) NSDictionary *fieldTemplate;
 @property (nonatomic, readonly) BOOL isSortable;

--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -47,6 +47,7 @@ NSString *const FXFormFieldType = @"type";
 NSString *const FXFormFieldClass = @"class";
 NSString *const FXFormFieldCell = @"cell";
 NSString *const FXFormFieldTitle = @"title";
+NSString *const FXFormFieldDetail = @"detail";
 NSString *const FXFormFieldPlaceholder = @"placeholder";
 NSString *const FXFormFieldDefaultValue = @"default";
 NSString *const FXFormFieldOptions = @"options";
@@ -848,6 +849,10 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
     if (descriptionKey && [self.form respondsToSelector:NSSelectorFromString(descriptionKey)])
     {
         return [(NSObject *)self.form valueForKey:descriptionKey];
+    }
+    
+    if (self.detail) {
+        return self.detail;
     }
     
     if (self.options)
@@ -2705,7 +2710,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
     }
     else if ([self.field.type isEqualToString:FXFormFieldTypeBoolean] || [self.field.type isEqualToString:FXFormFieldTypeOption])
     {
-        self.detailTextLabel.text = nil;
+        self.detailTextLabel.text = self.field.detail;
         self.accessoryType = [self.field.value boolValue]? UITableViewCellAccessoryCheckmark: UITableViewCellAccessoryNone;
     }
     else if (self.field.action)

--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -47,7 +47,6 @@ NSString *const FXFormFieldType = @"type";
 NSString *const FXFormFieldClass = @"class";
 NSString *const FXFormFieldCell = @"cell";
 NSString *const FXFormFieldTitle = @"title";
-NSString *const FXFormFieldDetail = @"detail";
 NSString *const FXFormFieldPlaceholder = @"placeholder";
 NSString *const FXFormFieldDefaultValue = @"default";
 NSString *const FXFormFieldOptions = @"options";
@@ -849,10 +848,6 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
     if (descriptionKey && [self.form respondsToSelector:NSSelectorFromString(descriptionKey)])
     {
         return [(NSObject *)self.form valueForKey:descriptionKey];
-    }
-    
-    if (self.detail) {
-        return self.detail;
     }
     
     if (self.options)
@@ -2710,7 +2705,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
     }
     else if ([self.field.type isEqualToString:FXFormFieldTypeBoolean] || [self.field.type isEqualToString:FXFormFieldTypeOption])
     {
-        self.detailTextLabel.text = self.field.detail;
+        self.detailTextLabel.text = nil;
         self.accessoryType = [self.field.value boolValue]? UITableViewCellAccessoryCheckmark: UITableViewCellAccessoryNone;
     }
     else if (self.field.action)

--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -761,7 +761,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
         BOOL canGetFieldConfig = FXFormCanGetValueForKey(form, @"field.cellConfig");
         NSObject *typedObj = form;
         id formField = canGetField ? [typedObj valueForKey:@"field"] : nil;
-        id formFieldConfig = canGetFieldConfig ? [typedObj valueForKey:@"field.cellConfig"] : nil;
+        id formFieldConfig = canGetFieldConfig ? [typedObj valueForKeyPath:@"field.cellConfig"] : nil;
         if (formField && formFieldConfig) {
             _cellConfig = formFieldConfig;
         } else {
@@ -1431,7 +1431,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
     return self;
 }
 
-- (id)valueForKey:(NSString *)key
+- (id)valueForUndefinedKey:(NSString *)key
 {
     NSInteger index = [key integerValue];
     return @([self.field isOptionSelectedAtIndex:index]);

--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -2004,6 +2004,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
 {
     _form = form;
     self.sections = [FXFormSection sectionsWithForm:form controller:self];
+    [self.tableView reloadData];//So the form changes
 }
 
 - (NSUInteger)numberOfSections


### PR DESCRIPTION
This PR fixes 2 things:
1) When assigning a new form to a formController or reassigning the existing one the content doesn't refresh, so a "reloadData" was added just after the form is assigned.

2) When dealing with "multiple choice" fields the app was crashing due to the fact that "valueForKey" was returning the "value" instead of the "field" object inside FXFormOption.
Using "valueForKeyPath" and changing the current overriding of "valueForKey" to "valueForUndefinedKey" seems to fix this issue.
To reproduce the issue just run the "BasicExample" with the current form, go to Register and select Gender.