### PR TITLE
reloadData + valueForKeyPath

### DIFF
--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -761,7 +761,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
         BOOL canGetFieldConfig = FXFormCanGetValueForKey(form, @"field.cellConfig");
         NSObject *typedObj = form;
         id formField = canGetField ? [typedObj valueForKey:@"field"] : nil;
-        id formFieldConfig = canGetFieldConfig ? [typedObj valueForKey:@"field.cellConfig"] : nil;
+        id formFieldConfig = canGetFieldConfig ? [typedObj valueForKeyPath:@"field.cellConfig"] : nil;
         if (formField && formFieldConfig) {
             _cellConfig = formFieldConfig;
         } else {
@@ -1431,7 +1431,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
     return self;
 }
 
-- (id)valueForKey:(NSString *)key
+- (id)valueForUndefinedKey:(NSString *)key
 {
     NSInteger index = [key integerValue];
     return @([self.field isOptionSelectedAtIndex:index]);

--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -2004,6 +2004,7 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
 {
     _form = form;
     self.sections = [FXFormSection sectionsWithForm:form controller:self];
+    [self.tableView reloadData];//So the form changes
 }
 
 - (NSUInteger)numberOfSections


### PR DESCRIPTION
This PR fixes 2 things:
1) When assigning a new form to a formController or reassigning the existing one the content doesn't refresh, so a "reloadData" was added just after the form is assigned.

2) When dealing with "multiple choice" fields the app was crashing due to the fact that "valueForKey" was returning the "value" instead of the "field" object inside FXFormOption.
Using "valueForKeyPath" and changing the current overriding of "valueForKey" to "valueForUndefinedKey" seems to fix this issue.
To reproduce the issue just run the "BasicExample" with the current form, go to Register and select Gender.