### PR TITLE
fix enum default value not work bug 

### DIFF
--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -973,7 +973,8 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
                 if (![self.options containsObject:value]) value = nil;
             }
         }
-        if (!value && self.defaultValue)
+        BOOL isZero = [self.valueClass isSubclassOfClass:[NSNumber class]] && [value intValue] == 0;
+        if ((!value || isZero) && self.defaultValue)
         {
             self.value = value = self.defaultValue;
         }


### PR DESCRIPTION
fix https://github.com/nicklockwood/FXForms/issues/339

originally , 

``` objc
if (!value && self.defaultValue) {
    self.value = value = self.defaultValue;
}
```

when I debug into it, 

![image](https://cloud.githubusercontent.com/assets/5022872/8626672/61edd964-2778-11e5-872b-e5f1ea8f9342.png)

so !value is false ，then not go into the block .

so I think we should recognize the default enum value 。
