### PR TITLE
Improving Swift 1.2 compatibility

### DIFF
--- a/Examples/SwiftExample/SwiftExample.xcodeproj/project.pbxproj
+++ b/Examples/SwiftExample/SwiftExample.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		01645D5D19D944080063EC7B /* FXForms.m in Sources */ = {isa = PBXBuildFile; fileRef = 01645D5C19D944080063EC7B /* FXForms.m */; };
 		01645D6219D944BE0063EC7B /* RegistrationForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01645D6119D944BE0063EC7B /* RegistrationForm.swift */; };
 		01645D6519D9559E0063EC7B /* ISO3166CountryValueTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01645D6419D9559E0063EC7B /* ISO3166CountryValueTransformer.swift */; };
+		1EF7B8EF1B5E9885000B19D6 /* SubmitButtonCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1EF7B8EE1B5E9885000B19D6 /* SubmitButtonCell.xib */; };
+		1EF7B8F11B5E991F000B19D6 /* SubmitButtonCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EF7B8F01B5E991F000B19D6 /* SubmitButtonCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -30,6 +32,8 @@
 		01645D6119D944BE0063EC7B /* RegistrationForm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegistrationForm.swift; sourceTree = "<group>"; };
 		01645D6319D9452A0063EC7B /* SwiftExample-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SwiftExample-Bridging-Header.h"; sourceTree = "<group>"; };
 		01645D6419D9559E0063EC7B /* ISO3166CountryValueTransformer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ISO3166CountryValueTransformer.swift; sourceTree = "<group>"; };
+		1EF7B8EE1B5E9885000B19D6 /* SubmitButtonCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SubmitButtonCell.xib; sourceTree = "<group>"; };
+		1EF7B8F01B5E991F000B19D6 /* SubmitButtonCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubmitButtonCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -63,6 +67,7 @@
 		01645D3719D943F40063EC7B /* SwiftExample */ = {
 			isa = PBXGroup;
 			children = (
+				1EF7B8ED1B5E986F000B19D6 /* Cells */,
 				01645D5E19D944350063EC7B /* Transformers */,
 				01645D6019D9444F0063EC7B /* Models */,
 				01645D5F19D9443F0063EC7B /* Controllers */,
@@ -116,6 +121,15 @@
 				01645D6119D944BE0063EC7B /* RegistrationForm.swift */,
 			);
 			name = Models;
+			sourceTree = "<group>";
+		};
+		1EF7B8ED1B5E986F000B19D6 /* Cells */ = {
+			isa = PBXGroup;
+			children = (
+				1EF7B8EE1B5E9885000B19D6 /* SubmitButtonCell.xib */,
+				1EF7B8F01B5E991F000B19D6 /* SubmitButtonCell.swift */,
+			);
+			name = Cells;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -176,6 +190,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				01645D4019D943F40063EC7B /* Main.storyboard in Resources */,
+				1EF7B8EF1B5E9885000B19D6 /* SubmitButtonCell.xib in Resources */,
 				01645D4519D943F40063EC7B /* LaunchScreen.xib in Resources */,
 				01645D4219D943F40063EC7B /* Images.xcassets in Resources */,
 			);
@@ -191,6 +206,7 @@
 				01645D6219D944BE0063EC7B /* RegistrationForm.swift in Sources */,
 				01645D6519D9559E0063EC7B /* ISO3166CountryValueTransformer.swift in Sources */,
 				01645D3D19D943F40063EC7B /* RegistrationFormViewController.swift in Sources */,
+				1EF7B8F11B5E991F000B19D6 /* SubmitButtonCell.swift in Sources */,
 				01645D5D19D944080063EC7B /* FXForms.m in Sources */,
 				01645D3B19D943F40063EC7B /* AppDelegate.swift in Sources */,
 			);

--- a/Examples/SwiftExample/SwiftExample/RegistrationForm.swift
+++ b/Examples/SwiftExample/SwiftExample/RegistrationForm.swift
@@ -23,7 +23,7 @@ class RegistrationForm: NSObject, FXForm {
     var phone: String?
     var country: String?
     var language: String?
-    var interests: NSArray? //NOTE: [String] or [AnyObject] won't work
+    var interests: [AnyObject]?
     var otherInterests = 0
     var about: String?
     
@@ -38,7 +38,7 @@ class RegistrationForm: NSObject, FXForm {
     //which lets us dictate exactly which fields appear
     //and in what order they appear
         
-    func fields() -> NSArray {
+    func fields() -> [AnyObject] {
         
         return [
         
@@ -137,13 +137,18 @@ class RegistrationForm: NSObject, FXForm {
             //FXFormFieldTypeOption will use an checkmark instead of a switch by default)
             
             [FXFormFieldKey: "agreedToTerms", FXFormFieldTitle: "I Agree To These Terms", FXFormFieldType: FXFormFieldTypeOption],
-            
+        ]
+    }
+   
+    func extraFields() -> [AnyObject] {
+        
+        return [
             //this field doesn't correspond to any property of the form
             //it's just an action button. the action will be called on first
             //object in the responder chain that implements the submitForm
             //method, which in this case would be the AppDelegate
             
-            [FXFormFieldTitle: "Submit", FXFormFieldHeader: "", FXFormFieldAction: "submitRegistrationForm:"],
+            [FXFormFieldCell: SubmitButtonCell.self, FXFormFieldHeader: "", FXFormFieldAction: "submitRegistrationForm:"],
         ]
     }
 }

--- a/Examples/SwiftExample/SwiftExample/RegistrationFormViewController.swift
+++ b/Examples/SwiftExample/SwiftExample/RegistrationFormViewController.swift
@@ -18,7 +18,7 @@ class RegistrationFormViewController: FXFormViewController {
     func submitRegistrationForm(cell: FXFormFieldCellProtocol) {
         
         //we can lookup the form from the cell if we want, like this:
-        let form = cell.field.form as RegistrationForm
+        let form = cell.field.form as! RegistrationForm
     
         //we can then perform validation, etc
         if form.agreedToTerms {

--- a/Examples/SwiftExample/SwiftExample/SubmitButtonCell.swift
+++ b/Examples/SwiftExample/SwiftExample/SubmitButtonCell.swift
@@ -1,0 +1,19 @@
+//
+//  SubmitButtonCell.swift
+//  SwiftExample
+//
+//  Created by Felipe Leal Coutinho on 21/07/15.
+//  Copyright (c) 2015 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+class SubmitButtonCell: FXFormBaseCell {
+    
+    @IBAction func buttonAction(sender: UIButton) {
+        if let action = field.action {
+            action(self)
+        }
+    }
+}

--- a/Examples/SwiftExample/SwiftExample/SubmitButtonCell.xib
+++ b/Examples/SwiftExample/SwiftExample/SubmitButtonCell.xib
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="f3N-f8-euX" customClass="SubmitButtonCell" customModule="SwiftExample" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="f3N-f8-euX" id="deh-Df-eC0">
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AuK-nB-4mS">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                        <color key="backgroundColor" red="0.0" green="1" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                        <state key="normal" title="Submit">
+                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                        </state>
+                        <connections>
+                            <action selector="buttonAction:" destination="f3N-f8-euX" eventType="touchUpInside" id="ZnI-g0-xCY"/>
+                        </connections>
+                    </button>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="bottom" secondItem="AuK-nB-4mS" secondAttribute="bottom" id="AxB-AI-LCg"/>
+                    <constraint firstItem="AuK-nB-4mS" firstAttribute="top" secondItem="deh-Df-eC0" secondAttribute="top" id="crk-65-RKs"/>
+                    <constraint firstItem="AuK-nB-4mS" firstAttribute="leading" secondItem="deh-Df-eC0" secondAttribute="leading" id="gDb-y7-pIF"/>
+                    <constraint firstAttribute="trailing" secondItem="AuK-nB-4mS" secondAttribute="trailing" id="krs-C5-5db"/>
+                </constraints>
+            </tableViewCellContentView>
+            <point key="canvasLocation" x="246" y="397"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -2119,6 +2119,9 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
     //don't recycle cells - it would make things complicated
     Class cellClass = field.cellClass ?: [self cellClassForField:field];
     NSString *nibName = NSStringFromClass(cellClass);
+    if ([nibName rangeOfString:@"."].location != NSNotFound) {
+        nibName = nibName.pathExtension; //Removes Swift namespace
+    }
     if ([[NSBundle mainBundle] pathForResource:nibName ofType:@"nib"])
     {
         //load cell from nib


### PR DESCRIPTION
Fixing SwiftExample with Swift 1.2 syntax.
The nib load with Swift was not working because Swift is a namespace language. So, if the nib name has the namespace, remove it.