### PR TITLE
Added support for prototype cells in storyboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.xccheckout
+Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample.xcodeproj/project.xcworkspace/xcuserdata
+Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample.xcodeproj/xcuserdata

--- a/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample.xcodeproj/project.pbxproj
+++ b/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample.xcodeproj/project.pbxproj
@@ -1,0 +1,498 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		146A226A1B65E56C004A4187 /* CustomCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 146A22691B65E56C004A4187 /* CustomCell.m */; };
+		146E0AFB1B65BDD400B41E1F /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 146E0AFA1B65BDD400B41E1F /* main.m */; };
+		146E0AFE1B65BDD400B41E1F /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 146E0AFD1B65BDD400B41E1F /* AppDelegate.m */; };
+		146E0B041B65BDD400B41E1F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 146E0B021B65BDD400B41E1F /* Main.storyboard */; };
+		146E0B061B65BDD400B41E1F /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 146E0B051B65BDD400B41E1F /* Images.xcassets */; };
+		146E0B091B65BDD400B41E1F /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 146E0B071B65BDD400B41E1F /* LaunchScreen.xib */; };
+		146E0B151B65BDD400B41E1F /* StoryboardCellTemplateExampleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 146E0B141B65BDD400B41E1F /* StoryboardCellTemplateExampleTests.m */; };
+		146E0B211B65BDFC00B41E1F /* FXForms.m in Sources */ = {isa = PBXBuildFile; fileRef = 146E0B201B65BDFC00B41E1F /* FXForms.m */; };
+		146E0B281B65BE5700B41E1F /* ISO3166CountryValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 146E0B231B65BE5700B41E1F /* ISO3166CountryValueTransformer.m */; };
+		146E0B291B65BE5700B41E1F /* RegistrationForm.m in Sources */ = {isa = PBXBuildFile; fileRef = 146E0B251B65BE5700B41E1F /* RegistrationForm.m */; };
+		146E0B2A1B65BE5700B41E1F /* RegistrationFormViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 146E0B271B65BE5700B41E1F /* RegistrationFormViewController.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		146E0B0F1B65BDD400B41E1F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 146E0AED1B65BDD400B41E1F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 146E0AF41B65BDD400B41E1F;
+			remoteInfo = StoryboardCellTemplateExample;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		146A22681B65E56C004A4187 /* CustomCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CustomCell.h; sourceTree = "<group>"; };
+		146A22691B65E56C004A4187 /* CustomCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CustomCell.m; sourceTree = "<group>"; };
+		146E0AF51B65BDD400B41E1F /* StoryboardCellTemplateExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StoryboardCellTemplateExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		146E0AF91B65BDD400B41E1F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		146E0AFA1B65BDD400B41E1F /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		146E0AFC1B65BDD400B41E1F /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		146E0AFD1B65BDD400B41E1F /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		146E0B031B65BDD400B41E1F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		146E0B051B65BDD400B41E1F /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		146E0B081B65BDD400B41E1F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
+		146E0B0E1B65BDD400B41E1F /* StoryboardCellTemplateExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StoryboardCellTemplateExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		146E0B131B65BDD400B41E1F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		146E0B141B65BDD400B41E1F /* StoryboardCellTemplateExampleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = StoryboardCellTemplateExampleTests.m; sourceTree = "<group>"; };
+		146E0B1F1B65BDFC00B41E1F /* FXForms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FXForms.h; sourceTree = "<group>"; };
+		146E0B201B65BDFC00B41E1F /* FXForms.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FXForms.m; sourceTree = "<group>"; };
+		146E0B221B65BE5700B41E1F /* ISO3166CountryValueTransformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ISO3166CountryValueTransformer.h; sourceTree = "<group>"; };
+		146E0B231B65BE5700B41E1F /* ISO3166CountryValueTransformer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ISO3166CountryValueTransformer.m; sourceTree = "<group>"; };
+		146E0B241B65BE5700B41E1F /* RegistrationForm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RegistrationForm.h; sourceTree = "<group>"; };
+		146E0B251B65BE5700B41E1F /* RegistrationForm.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RegistrationForm.m; sourceTree = "<group>"; };
+		146E0B261B65BE5700B41E1F /* RegistrationFormViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RegistrationFormViewController.h; sourceTree = "<group>"; };
+		146E0B271B65BE5700B41E1F /* RegistrationFormViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RegistrationFormViewController.m; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		146E0AF21B65BDD400B41E1F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		146E0B0B1B65BDD400B41E1F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		146A226B1B65E571004A4187 /* Cells */ = {
+			isa = PBXGroup;
+			children = (
+				146A22681B65E56C004A4187 /* CustomCell.h */,
+				146A22691B65E56C004A4187 /* CustomCell.m */,
+			);
+			name = Cells;
+			sourceTree = "<group>";
+		};
+		146E0AEC1B65BDD400B41E1F = {
+			isa = PBXGroup;
+			children = (
+				146E0B1E1B65BDFC00B41E1F /* FXForms */,
+				146E0AF71B65BDD400B41E1F /* StoryboardCellTemplateExample */,
+				146E0B111B65BDD400B41E1F /* StoryboardCellTemplateExampleTests */,
+				146E0AF61B65BDD400B41E1F /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		146E0AF61B65BDD400B41E1F /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				146E0AF51B65BDD400B41E1F /* StoryboardCellTemplateExample.app */,
+				146E0B0E1B65BDD400B41E1F /* StoryboardCellTemplateExampleTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		146E0AF71B65BDD400B41E1F /* StoryboardCellTemplateExample */ = {
+			isa = PBXGroup;
+			children = (
+				146E0B2B1B65BE6200B41E1F /* Transformers */,
+				146E0B2C1B65BE7300B41E1F /* Models */,
+				146A226B1B65E571004A4187 /* Cells */,
+				146E0B2D1B65BE9900B41E1F /* Controllers */,
+				146E0B051B65BDD400B41E1F /* Images.xcassets */,
+				146E0B071B65BDD400B41E1F /* LaunchScreen.xib */,
+				146E0AF81B65BDD400B41E1F /* Supporting Files */,
+			);
+			path = StoryboardCellTemplateExample;
+			sourceTree = "<group>";
+		};
+		146E0AF81B65BDD400B41E1F /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				146E0AF91B65BDD400B41E1F /* Info.plist */,
+				146E0AFA1B65BDD400B41E1F /* main.m */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		146E0B111B65BDD400B41E1F /* StoryboardCellTemplateExampleTests */ = {
+			isa = PBXGroup;
+			children = (
+				146E0B141B65BDD400B41E1F /* StoryboardCellTemplateExampleTests.m */,
+				146E0B121B65BDD400B41E1F /* Supporting Files */,
+			);
+			path = StoryboardCellTemplateExampleTests;
+			sourceTree = "<group>";
+		};
+		146E0B121B65BDD400B41E1F /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				146E0B131B65BDD400B41E1F /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		146E0B1E1B65BDFC00B41E1F /* FXForms */ = {
+			isa = PBXGroup;
+			children = (
+				146E0B1F1B65BDFC00B41E1F /* FXForms.h */,
+				146E0B201B65BDFC00B41E1F /* FXForms.m */,
+			);
+			name = FXForms;
+			path = ../../FXForms;
+			sourceTree = "<group>";
+		};
+		146E0B2B1B65BE6200B41E1F /* Transformers */ = {
+			isa = PBXGroup;
+			children = (
+				146E0B221B65BE5700B41E1F /* ISO3166CountryValueTransformer.h */,
+				146E0B231B65BE5700B41E1F /* ISO3166CountryValueTransformer.m */,
+			);
+			name = Transformers;
+			sourceTree = "<group>";
+		};
+		146E0B2C1B65BE7300B41E1F /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				146E0B241B65BE5700B41E1F /* RegistrationForm.h */,
+				146E0B251B65BE5700B41E1F /* RegistrationForm.m */,
+			);
+			name = Models;
+			sourceTree = "<group>";
+		};
+		146E0B2D1B65BE9900B41E1F /* Controllers */ = {
+			isa = PBXGroup;
+			children = (
+				146E0AFC1B65BDD400B41E1F /* AppDelegate.h */,
+				146E0AFD1B65BDD400B41E1F /* AppDelegate.m */,
+				146E0B021B65BDD400B41E1F /* Main.storyboard */,
+				146E0B261B65BE5700B41E1F /* RegistrationFormViewController.h */,
+				146E0B271B65BE5700B41E1F /* RegistrationFormViewController.m */,
+			);
+			name = Controllers;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		146E0AF41B65BDD400B41E1F /* StoryboardCellTemplateExample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 146E0B181B65BDD400B41E1F /* Build configuration list for PBXNativeTarget "StoryboardCellTemplateExample" */;
+			buildPhases = (
+				146E0AF11B65BDD400B41E1F /* Sources */,
+				146E0AF21B65BDD400B41E1F /* Frameworks */,
+				146E0AF31B65BDD400B41E1F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = StoryboardCellTemplateExample;
+			productName = StoryboardCellTemplateExample;
+			productReference = 146E0AF51B65BDD400B41E1F /* StoryboardCellTemplateExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+		146E0B0D1B65BDD400B41E1F /* StoryboardCellTemplateExampleTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 146E0B1B1B65BDD400B41E1F /* Build configuration list for PBXNativeTarget "StoryboardCellTemplateExampleTests" */;
+			buildPhases = (
+				146E0B0A1B65BDD400B41E1F /* Sources */,
+				146E0B0B1B65BDD400B41E1F /* Frameworks */,
+				146E0B0C1B65BDD400B41E1F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				146E0B101B65BDD400B41E1F /* PBXTargetDependency */,
+			);
+			name = StoryboardCellTemplateExampleTests;
+			productName = StoryboardCellTemplateExampleTests;
+			productReference = 146E0B0E1B65BDD400B41E1F /* StoryboardCellTemplateExampleTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		146E0AED1B65BDD400B41E1F /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0640;
+				ORGANIZATIONNAME = ifullgaz.com;
+				TargetAttributes = {
+					146E0AF41B65BDD400B41E1F = {
+						CreatedOnToolsVersion = 6.4;
+					};
+					146E0B0D1B65BDD400B41E1F = {
+						CreatedOnToolsVersion = 6.4;
+						TestTargetID = 146E0AF41B65BDD400B41E1F;
+					};
+				};
+			};
+			buildConfigurationList = 146E0AF01B65BDD400B41E1F /* Build configuration list for PBXProject "StoryboardCellTemplateExample" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 146E0AEC1B65BDD400B41E1F;
+			productRefGroup = 146E0AF61B65BDD400B41E1F /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				146E0AF41B65BDD400B41E1F /* StoryboardCellTemplateExample */,
+				146E0B0D1B65BDD400B41E1F /* StoryboardCellTemplateExampleTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		146E0AF31B65BDD400B41E1F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				146E0B041B65BDD400B41E1F /* Main.storyboard in Resources */,
+				146E0B091B65BDD400B41E1F /* LaunchScreen.xib in Resources */,
+				146E0B061B65BDD400B41E1F /* Images.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		146E0B0C1B65BDD400B41E1F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		146E0AF11B65BDD400B41E1F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				146E0B281B65BE5700B41E1F /* ISO3166CountryValueTransformer.m in Sources */,
+				146E0B211B65BDFC00B41E1F /* FXForms.m in Sources */,
+				146E0B2A1B65BE5700B41E1F /* RegistrationFormViewController.m in Sources */,
+				146E0AFE1B65BDD400B41E1F /* AppDelegate.m in Sources */,
+				146A226A1B65E56C004A4187 /* CustomCell.m in Sources */,
+				146E0B291B65BE5700B41E1F /* RegistrationForm.m in Sources */,
+				146E0AFB1B65BDD400B41E1F /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		146E0B0A1B65BDD400B41E1F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				146E0B151B65BDD400B41E1F /* StoryboardCellTemplateExampleTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		146E0B101B65BDD400B41E1F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 146E0AF41B65BDD400B41E1F /* StoryboardCellTemplateExample */;
+			targetProxy = 146E0B0F1B65BDD400B41E1F /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		146E0B021B65BDD400B41E1F /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				146E0B031B65BDD400B41E1F /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		146E0B071B65BDD400B41E1F /* LaunchScreen.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				146E0B081B65BDD400B41E1F /* Base */,
+			);
+			name = LaunchScreen.xib;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		146E0B161B65BDD400B41E1F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		146E0B171B65BDD400B41E1F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		146E0B191B65BDD400B41E1F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = StoryboardCellTemplateExample/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		146E0B1A1B65BDD400B41E1F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = StoryboardCellTemplateExample/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		146E0B1C1B65BDD400B41E1F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = StoryboardCellTemplateExampleTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/StoryboardCellTemplateExample.app/StoryboardCellTemplateExample";
+			};
+			name = Debug;
+		};
+		146E0B1D1B65BDD400B41E1F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = StoryboardCellTemplateExampleTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/StoryboardCellTemplateExample.app/StoryboardCellTemplateExample";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		146E0AF01B65BDD400B41E1F /* Build configuration list for PBXProject "StoryboardCellTemplateExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				146E0B161B65BDD400B41E1F /* Debug */,
+				146E0B171B65BDD400B41E1F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		146E0B181B65BDD400B41E1F /* Build configuration list for PBXNativeTarget "StoryboardCellTemplateExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				146E0B191B65BDD400B41E1F /* Debug */,
+				146E0B1A1B65BDD400B41E1F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		146E0B1B1B65BDD400B41E1F /* Build configuration list for PBXNativeTarget "StoryboardCellTemplateExampleTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				146E0B1C1B65BDD400B41E1F /* Debug */,
+				146E0B1D1B65BDD400B41E1F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 146E0AED1B65BDD400B41E1F /* Project object */;
+}

--- a/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:StoryboardCellTemplateExample.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/AppDelegate.h
+++ b/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/AppDelegate.h
@@ -1,0 +1,17 @@
+//
+//  AppDelegate.h
+//  StoryboardCellTemplateExample
+//
+//  Created by Emmanuel Merali on 27/07/2015.
+//  Copyright (c) 2015 ifullgaz.com. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+
+@end
+

--- a/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/AppDelegate.m
+++ b/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/AppDelegate.m
@@ -1,0 +1,45 @@
+//
+//  AppDelegate.m
+//  StoryboardCellTemplateExample
+//
+//  Created by Emmanuel Merali on 27/07/2015.
+//  Copyright (c) 2015 ifullgaz.com. All rights reserved.
+//
+
+#import "AppDelegate.h"
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    // Override point for customization after application launch.
+    return YES;
+}
+
+- (void)applicationWillResignActive:(UIApplication *)application {
+    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+    // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+}
+
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+}
+
+- (void)applicationWillEnterForeground:(UIApplication *)application {
+    // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+}
+
+- (void)applicationDidBecomeActive:(UIApplication *)application {
+    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+}
+
+- (void)applicationWillTerminate:(UIApplication *)application {
+    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+}
+
+@end

--- a/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/Base.lproj/LaunchScreen.xib
+++ b/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/Base.lproj/LaunchScreen.xib
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6214" systemVersion="14A314h" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6207"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2015 ifullgaz.com. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
+                    <rect key="frame" x="20" y="439" width="441" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="StoryboardCellTemplateExample" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="kId-c2-rCX">
+                    <rect key="frame" x="20" y="140" width="441" height="43"/>
+                    <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="kId-c2-rCX" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="bottom" multiplier="1/3" constant="1" id="5cJ-9S-tgC"/>
+                <constraint firstAttribute="centerX" secondItem="kId-c2-rCX" secondAttribute="centerX" id="Koa-jz-hwk"/>
+                <constraint firstAttribute="bottom" secondItem="8ie-xW-0ye" secondAttribute="bottom" constant="20" id="Kzo-t9-V3l"/>
+                <constraint firstItem="8ie-xW-0ye" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="MfP-vx-nX0"/>
+                <constraint firstAttribute="centerX" secondItem="8ie-xW-0ye" secondAttribute="centerX" id="ZEH-qu-HZ9"/>
+                <constraint firstItem="kId-c2-rCX" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="fvb-Df-36g"/>
+            </constraints>
+            <nil key="simulatedStatusBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="548" y="455"/>
+        </view>
+    </objects>
+</document>

--- a/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/Base.lproj/Main.storyboard
+++ b/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/Base.lproj/Main.storyboard
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="UMH-dU-9BU">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+    </dependencies>
+    <scenes>
+        <!--Registration Form View Controller-->
+        <scene sceneID="ufC-wZ-h7g">
+            <objects>
+                <viewController id="vXZ-lx-hvc" customClass="RegistrationFormViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="jyV-Pf-zRb"/>
+                        <viewControllerLayoutGuide type="bottom" id="2fi-mo-0CV"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="kh9-bI-dsS">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" translatesAutoresizingMaskIntoConstraints="NO" id="WnB-lV-9kw">
+                                <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                                <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                                <prototypes>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="CellIdentifier" textLabel="hj3-LT-JwQ" rowHeight="100" style="IBUITableViewCellStyleDefault" id="Hdt-pi-1r7" customClass="CustomCell">
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Hdt-pi-1r7" id="ShH-9Y-jvR">
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="hj3-LT-JwQ">
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="WnB-lV-9kw" firstAttribute="top" secondItem="kh9-bI-dsS" secondAttribute="top" id="BZm-lY-mI1"/>
+                            <constraint firstItem="WnB-lV-9kw" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leading" id="Ljm-ix-mOn"/>
+                            <constraint firstAttribute="bottom" secondItem="WnB-lV-9kw" secondAttribute="bottom" id="No6-mP-deR"/>
+                            <constraint firstAttribute="trailing" secondItem="WnB-lV-9kw" secondAttribute="trailing" id="xj4-Pe-3wx"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="K07-aW-ivI"/>
+                    <connections>
+                        <outlet property="tableView" destination="WnB-lV-9kw" id="lPQ-xi-Cae"/>
+                        <segue destination="s4q-oS-ySX" kind="push" identifier="TermsSegue" id="Qy1-aC-Run"/>
+                        <segue destination="lP2-qE-edZ" kind="push" identifier="PrivacyPolicySegue" id="jI5-gP-Ifv"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="x5A-6p-PRh" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="585" y="174"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="MFV-c5-YRi">
+            <objects>
+                <viewController id="lP2-qE-edZ" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="kkZ-Qn-9st"/>
+                        <viewControllerLayoutGuide type="bottom" id="EE5-8u-dbt"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="bT9-YD-AQj">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <subviews>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="280" translatesAutoresizingMaskIntoConstraints="NO" id="AIh-yI-Fux">
+                                <rect key="frame" x="20" y="91" width="280" height="263"/>
+                                <string key="text">Blah Blah Blah
+
+We take our customers' privacy very seriously, which is why we store all passwords using ROT13 encoding in a text file on our server.  We have every intention of selling your data to advertisers and/or handing your details to the NSA. Hope that's OK.</string>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="KTQ-UQ-S7E"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="yLV-yQ-aJ4" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1080" y="614"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="rmG-cE-dPD">
+            <objects>
+                <viewController id="s4q-oS-ySX" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="mB1-R8-da1"/>
+                        <viewControllerLayoutGuide type="bottom" id="54o-ml-qAm"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="huw-9H-wOn">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <subviews>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="280" translatesAutoresizingMaskIntoConstraints="NO" id="rek-Bc-Hvs">
+                                <rect key="frame" x="20" y="88" width="280" height="230"/>
+                                <string key="text">Blah Blah Blah  By registering for this product or service you agree that all your base are belong to us.  SCARY LEGAL MUMBO JUMBO IN ALL CAPS FOR SOME REASON. ON PENALTY OF DEATH.</string>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="xIa-60-ybZ"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="OkH-CS-77H" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1080" y="-89"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="tXc-AG-scW">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="UMH-dU-9BU" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="rcG-aP-hCb">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="vXZ-lx-hvc" kind="relationship" relationship="rootViewController" id="RTl-t3-0N8"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="DkH-gh-u4f" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="92" y="174"/>
+        </scene>
+    </scenes>
+    <simulatedMetricsContainer key="defaultSimulatedMetrics">
+        <simulatedStatusBarMetrics key="statusBar"/>
+        <simulatedOrientationMetrics key="orientation"/>
+        <simulatedScreenMetrics key="destination" type="retina4"/>
+    </simulatedMetricsContainer>
+</document>

--- a/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/CustomCell.h
+++ b/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/CustomCell.h
@@ -1,0 +1,13 @@
+//
+//  CustomCell.h
+//  StoryboardCellTemplateExample
+//
+//  Created by Emmanuel Merali on 27/07/2015.
+//  Copyright (c) 2015 ifullgaz.com. All rights reserved.
+//
+
+#import "FXForms.h"
+
+@interface CustomCell : FXFormTextFieldCell
+
+@end

--- a/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/CustomCell.m
+++ b/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/CustomCell.m
@@ -1,0 +1,17 @@
+//
+//  CustomCell.m
+//  StoryboardCellTemplateExample
+//
+//  Created by Emmanuel Merali on 27/07/2015.
+//  Copyright (c) 2015 ifullgaz.com. All rights reserved.
+//
+
+#import "CustomCell.h"
+
+@implementation CustomCell
+
++ (CGFloat)heightForField:(FXFormField *)field width:(CGFloat)width {
+    return 65.0;
+}
+
+@end

--- a/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/ISO3166CountryValueTransformer.h
+++ b/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/ISO3166CountryValueTransformer.h
@@ -1,0 +1,13 @@
+//
+//  ISO3166CountryValueTransformer.h
+//  BasicExample
+//
+//  Created by Bart Vandendriessche on 17/03/14.
+//  Copyright (c) 2014 Charcoal Design. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface ISO3166CountryValueTransformer : NSValueTransformer
+
+@end

--- a/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/ISO3166CountryValueTransformer.m
+++ b/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/ISO3166CountryValueTransformer.m
@@ -1,0 +1,28 @@
+//
+//  ISO3166CountryValueTransformer.m
+//  BasicExample
+//
+//  Created by Bart Vandendriessche on 17/03/14.
+//  Copyright (c) 2014 Charcoal Design. All rights reserved.
+//
+
+#import "ISO3166CountryValueTransformer.h"
+
+@implementation ISO3166CountryValueTransformer
+
++ (Class)transformedValueClass
+{
+    return [NSString class];
+}
+
++ (BOOL)allowsReverseTransformation
+{
+    return NO;
+}
+
+- (id)transformedValue:(id)value
+{
+    return value? [[NSLocale localeWithLocaleIdentifier:@"en_US"] displayNameForKey:NSLocaleCountryCode value:value]: nil;
+}
+
+@end

--- a/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/Info.plist
+++ b/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.ifullgaz.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/RegistrationForm.h
+++ b/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/RegistrationForm.h
@@ -1,0 +1,61 @@
+//
+//  RegistrationForm.h
+//  BasicExample
+//
+//  Created by Nick Lockwood on 04/03/2014.
+//  Copyright (c) 2014 Charcoal Design. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "FXForms.h"
+
+
+typedef NS_ENUM(NSInteger, Gender)
+{
+    GenderMale = 0,
+    GenderFemale,
+    GenderOther
+};
+
+
+typedef NS_OPTIONS(NSInteger, Interests)
+{
+    InterestComputers = 1 << 0,
+    InterestSocializing = 1 << 1,
+    InterestSports = 1 << 2
+};
+
+
+typedef NS_OPTIONS(NSInteger, ServicePlan)
+{
+    ServicePlanMicro = 0,
+    ServicePlanNormal,
+    ServicePlanMaxi
+};
+
+
+@interface RegistrationForm : NSObject <FXForm>
+
+@property (nonatomic, copy) NSString *email;
+@property (nonatomic, copy) NSString *password;
+@property (nonatomic, copy) NSString *repeatPassword;
+
+@property (nonatomic, copy) NSString *name;
+@property (nonatomic, assign) Gender gender;
+@property (nonatomic, assign) NSUInteger age;
+@property (nonatomic, strong) NSDate *dateOfBirth;
+@property (nonatomic, strong) UIImage *profilePhoto;
+@property (nonatomic, copy) NSString *phone;
+@property (nonatomic, copy) NSString *country;
+@property (nonatomic, copy) NSString *language;
+@property (nonatomic, copy) NSArray *interests;
+@property (nonatomic, assign) Interests otherInterests;
+@property (nonatomic, copy) NSString *about;
+
+@property (nonatomic, assign) ServicePlan plan;
+
+@property (nonatomic, copy) NSString *notifications;
+
+@property (nonatomic, assign) BOOL agreedToTerms;
+
+@end

--- a/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/RegistrationForm.m
+++ b/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/RegistrationForm.m
@@ -1,0 +1,135 @@
+//
+//  RegistrationForm.m
+//  BasicExample
+//
+//  Created by Nick Lockwood on 04/03/2014.
+//  Copyright (c) 2014 Charcoal Design. All rights reserved.
+//
+
+#import "RegistrationForm.h"
+#import "ISO3166CountryValueTransformer.h"
+
+
+@implementation RegistrationForm
+
+//because we want to rearrange how this form
+//is displayed, we've implemented the fields array
+//which lets us dictate exactly which fields appear
+//and in what order they appear
+
+- (NSArray *)fields
+{
+    return @[
+             
+             //we want to add a group header for the field set of fields
+             //we do that by adding the header key to the first field in the group
+             
+             @{FXFormFieldHeader: @"Account",
+               FXFormFieldKey: @"email",
+               FXFormFieldCell: @"CustomCell",
+               FXFormFieldCellIdentifier: @"CellIdentifier"
+               },
+             
+             //we don't need to modify these fields at all, so we'll
+             //just refer to them by name to use the default settings
+             
+             @"password",
+             @"repeatPassword",
+             
+             //we want to add another group header here, and modify the auto-capitalization
+             
+             @{FXFormFieldKey: @"name",
+               FXFormFieldHeader: @"Details",
+               @"textField.autocapitalizationType": @(UITextAutocapitalizationTypeWords)},
+             
+             //this is a multiple choice field, so we'll need to provide some options
+             //because this is an enum property, the indexes of the options should match enum values
+             
+             @{FXFormFieldKey: @"gender", FXFormFieldOptions: @[@"Male", @"Female", @"It's Complicated"]},
+             
+             //another regular field
+             
+             @"dateOfBirth",
+             
+             //we want to use a stepper control for this value, so let's specify that
+             
+             @{FXFormFieldKey: @"age", FXFormFieldCell: [FXFormStepperCell class]},
+             
+             //some more regular fields
+             
+             @"profilePhoto",
+             @"phone",
+             
+             //the country value in our form is a locale code, which isn't human readable
+             //so we've used the FXFormFieldValueTransformer option to supply a value transformer
+             
+             @{FXFormFieldKey: @"country",
+               FXFormFieldOptions: @[@"us", @"ca", @"gb", @"sa", @"be"],
+               FXFormFieldPlaceholder: @"None",
+               FXFormFieldValueTransformer: [[ISO3166CountryValueTransformer alloc] init]},
+             
+             //this is an options field that uses a FXFormOptionPickerCell to display the available
+             //options in a UIPickerView
+             
+             @{FXFormFieldKey: @"language",
+               FXFormFieldOptions: @[@"English", @"Spanish", @"French", @"Dutch"],
+               FXFormFieldPlaceholder: @"None",
+               FXFormFieldCell: [FXFormOptionPickerCell class]},
+             
+             //this is a multi-select options field - FXForms knows this because the
+             //class of the field property is a collection (in this case, NSArray)
+             
+             @{FXFormFieldKey: @"interests", FXFormFieldPlaceholder: @"None",
+               FXFormFieldOptions: @[@"Videogames", @"Animals", @"Cooking"]},
+             
+             //this is another multi-select options field, but in this case it's represented
+             //as a bitfield. FXForms can't infer this from the property (which is just an integer), so
+             //we explicitly specify the type as FXFormFieldTypeBitfield
+             
+             @{FXFormFieldKey: @"otherInterests",
+               FXFormFieldType: FXFormFieldTypeBitfield,
+               FXFormFieldPlaceholder: @"None",
+               FXFormFieldOptions: @[@"Computers", @"Socializing", @"Sports"]},
+
+             //this is a multiline text view that grows to fit its contents
+             
+             @{FXFormFieldKey: @"about", FXFormFieldType: FXFormFieldTypeLongText},
+             
+             //this is an options field that uses a FXFormOptionSegmentsCell to display the available
+             //options in a UIPickerView
+             
+             @{FXFormFieldHeader: @"Plan",
+               FXFormFieldKey: @"plan",
+               FXFormFieldTitle: @"",
+               FXFormFieldPlaceholder: @"Free",
+               FXFormFieldOptions: @[@"Micro", @"Normal", @"Maxi"],
+               FXFormFieldCell: [FXFormOptionSegmentsCell class]},
+             
+             //we've implemented the terms and privacy policy as segues, which means that
+             //they have to be set up with configuration dictionaries, as there's no way
+             //to infer them from the form properties
+             
+             @{FXFormFieldHeader: @"Legal",
+               FXFormFieldTitle: @"Terms And Conditions",
+               FXFormFieldSegue: @"TermsSegue"},
+             
+             @{FXFormFieldTitle: @"Privacy Policy",
+               FXFormFieldSegue: @"PrivacyPolicySegue"},
+             
+             //the automatically generated title (Agreed To Terms) and cell (FXFormSwitchCell)
+             //don't really work for this field, so we'll override them both (a type of
+             //FXFormFieldTypeOption will use an checkmark instead of a switch by default)
+             
+             @{FXFormFieldKey: @"agreedToTerms", FXFormFieldTitle: @"I Agree To These Terms", FXFormFieldType: FXFormFieldTypeOption},
+             
+             //this field doesn't correspond to any property of the form
+             //it's just an action button. the action will be called on first
+             //object in the responder chain that implements the submitForm
+             //method, which in this case would be the AppDelegate
+             
+             @{FXFormFieldTitle: @"Submit", FXFormFieldHeader: @"", FXFormFieldAction: @"submitRegistrationForm:"},
+             
+             ];
+}
+
+@end

--- a/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/RegistrationFormViewController.h
+++ b/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/RegistrationFormViewController.h
@@ -1,0 +1,13 @@
+//
+//  RegistrationFormViewController.h
+//  BasicExample
+//
+//  Created by Nick Lockwood on 25/03/2014.
+//  Copyright (c) 2014 Charcoal Design. All rights reserved.
+//
+
+#import "FXForms.h"
+
+@interface RegistrationFormViewController : FXFormViewController
+
+@end

--- a/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/RegistrationFormViewController.m
+++ b/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/RegistrationFormViewController.m
@@ -1,0 +1,38 @@
+//
+//  RegistrationFormViewController.m
+//  BasicExample
+//
+//  Created by Nick Lockwood on 25/03/2014.
+//  Copyright (c) 2014 Charcoal Design. All rights reserved.
+//
+
+#import "RegistrationFormViewController.h"
+#import "RegistrationForm.h"
+
+
+@implementation RegistrationFormViewController
+
+- (void)awakeFromNib
+{
+    [super awakeFromNib];
+    //set up form
+    self.formController.form = [[RegistrationForm alloc] init];
+}
+
+- (void)submitRegistrationForm:(UITableViewCell<FXFormFieldCell> *)cell
+{
+    //we can lookup the form from the cell if we want, like this:
+    RegistrationForm *form = cell.field.form;
+    
+    //we can then perform validation, etc
+    if (form.agreedToTerms)
+    {
+        [[[UIAlertView alloc] initWithTitle:@"Registration Form Submitted" message:nil delegate:nil cancelButtonTitle:nil otherButtonTitles:@"OK", nil] show];
+    }
+    else
+    {
+        [[[UIAlertView alloc] initWithTitle:@"User Error" message:@"Please agree to the terms and conditions before proceeding" delegate:nil cancelButtonTitle:nil otherButtonTitles:@"Yes Sir!", nil] show];
+    }
+}
+
+@end

--- a/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/main.m
+++ b/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExample/main.m
@@ -1,0 +1,16 @@
+//
+//  main.m
+//  StoryboardCellTemplateExample
+//
+//  Created by Emmanuel Merali on 27/07/2015.
+//  Copyright (c) 2015 ifullgaz.com. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[]) {
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    }
+}

--- a/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExampleTests/Info.plist
+++ b/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExampleTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.ifullgaz.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExampleTests/StoryboardCellTemplateExampleTests.m
+++ b/Examples/StoryboardCellTemplateExample/StoryboardCellTemplateExampleTests/StoryboardCellTemplateExampleTests.m
@@ -1,0 +1,40 @@
+//
+//  StoryboardCellTemplateExampleTests.m
+//  StoryboardCellTemplateExampleTests
+//
+//  Created by Emmanuel Merali on 27/07/2015.
+//  Copyright (c) 2015 ifullgaz.com. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+
+@interface StoryboardCellTemplateExampleTests : XCTestCase
+
+@end
+
+@implementation StoryboardCellTemplateExampleTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testExample {
+    // This is an example of a functional test case.
+    XCTAssert(YES, @"Pass");
+}
+
+- (void)testPerformanceExample {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+    }];
+}
+
+@end

--- a/FXForms/FXForms.h
+++ b/FXForms/FXForms.h
@@ -42,6 +42,7 @@ UIKIT_EXTERN NSString *const FXFormFieldKey; //key
 UIKIT_EXTERN NSString *const FXFormFieldType; //type
 UIKIT_EXTERN NSString *const FXFormFieldClass; //class
 UIKIT_EXTERN NSString *const FXFormFieldCell; //cell
+UIKIT_EXTERN NSString *const FXFormFieldCellIdentifier; //cellIdentifier
 UIKIT_EXTERN NSString *const FXFormFieldTitle; //title
 UIKIT_EXTERN NSString *const FXFormFieldPlaceholder; //placeholder
 UIKIT_EXTERN NSString *const FXFormFieldDefaultValue; //default


### PR DESCRIPTION
Added support for prototype cells in storyboard with a new example StoryboardCellTemplateExample.
Usage is simple:
1) Add a table to the form controller in storyboard and wire it to the tableView outlet
2) Add prototype cells as required
3) Assign a unique reuse identifier to each cell
4) In the form field definition add FXFormFieldCellIdentifier with value the cell identifier