### PR TITLE
Fix crash on Swift application when array item is NSNull

### DIFF
--- a/Examples/SwiftExample/SwiftExample/RegistrationForm.swift
+++ b/Examples/SwiftExample/SwiftExample/RegistrationForm.swift
@@ -27,6 +27,8 @@ class RegistrationForm: NSObject, FXForm {
     var otherInterests = 0
     var about: String?
     
+    var inlineArray: [String]?
+    
     var plan: Int = 0
     
     var notifications: String?
@@ -110,6 +112,9 @@ class RegistrationForm: NSObject, FXForm {
             //this is a multiline text view that grows to fit its contents
             
             [FXFormFieldKey: "about", FXFormFieldType: FXFormFieldTypeLongText],
+            
+            // this is a inline array
+            [FXFormFieldKey: "inlineArray", FXFormFieldInline: true, FXFormFieldHeader: "Inline Array"],
             
             //this is an options field that uses a FXFormOptionSegmentsCell to display the available
             //options in a UIPickerView

--- a/FXForms/FXForms.m
+++ b/FXForms/FXForms.m
@@ -1574,6 +1574,8 @@ static void FXFormPreprocessFieldDictionary(NSMutableDictionary *dictionary)
     else
     {
         [collection addObjectsFromArray:self.values];
+        // remove NSNull. because crash in 'setValue' on Swift application.
+        [collection removeObjectIdenticalTo:[NSNull null]];
     }
     
     //set field value


### PR DESCRIPTION
This changes was to fix crash in the Swift Application when array item is NSNull.

Steps to reproduce the crash

1. tap multiple times the 'Add Item'.
1. prepare empty field a plurality.
1. Any tap an empty field.
1. crash in 'setValue'.